### PR TITLE
Add charlesrotation point offset issue #56

### DIFF
--- a/src/js/core/transform/Draggable.js
+++ b/src/js/core/transform/Draggable.js
@@ -1333,6 +1333,39 @@ export default class Draggable extends Transformable {
         );
     }
 
+    offsetCenterPoint(nx,ny) {
+        const {
+            elements: [element] = [],
+            storage: {
+                wrapper,
+                handles: { center }
+            },
+            options: {
+                container
+            }
+        } = this;
+
+        if (!center) return;
+
+        const { offsetHeight, offsetWidth } = element;
+
+        const [offsetLeft, offsetTop] = getAbsoluteOffset(element, container);
+
+        const matrix = multiplyMatrix(
+            getCurrentTransformMatrix(element, container),
+            matrixInvert(getCurrentTransformMatrix(wrapper, wrapper.parentNode))
+        );
+
+        const [x, y] = multiplyMatrixAndPoint(
+            matrix,
+            [(offsetWidth / 2) + nx, (offsetHeight / 2) +ny, 0, 1]
+        );
+
+        helper(center).css(
+            { transform: `translate(${x + offsetLeft}px, ${y + offsetTop}px)` }
+        );
+    }
+
     fitControlsToSize() {
         const identityMatrix = createIdentityMatrix();
 

--- a/src/js/core/transform/svg/DraggableSVG.js
+++ b/src/js/core/transform/svg/DraggableSVG.js
@@ -1316,7 +1316,7 @@ export default class DraggableSVG extends Transformable {
         radius.x2.baseVal.value = x;
         radius.y2.baseVal.value = y;
 
-        center.isShifted = true;
+        center.isShifted = false;
     }
 
     fitControlsToSize() {

--- a/src/js/core/transform/svg/DraggableSVG.js
+++ b/src/js/core/transform/svg/DraggableSVG.js
@@ -1274,51 +1274,6 @@ export default class DraggableSVG extends Transformable {
         center.isShifted = false;
     }
 
-    resetCenterPoint() {
-        const {
-            elements,
-            storage: {
-                controls,
-                handles: {
-                    center: handle,
-                    radius
-                } = {},
-                center
-            } = {},
-            options: {
-                container,
-                isGrouped
-            }
-        } = this;
-
-        if (!center || !handle || !radius) return;
-
-        const { x: bx, y: by, width, height } = this._getBBox();
-
-        const hW = width / 2,
-            hH = height / 2;
-
-        const controlsTransformMatrix = getTransformToElement(controls, controls.parentNode).inverse();
-
-        const nextTransform = isGrouped
-            ? controlsTransformMatrix
-            : controlsTransformMatrix.multiply(getTransformToElement(elements[0], container));
-
-        const { x, y } = pointTo(
-            nextTransform,
-            bx + hW,
-            by + hH
-        );
-
-        handle.cx.baseVal.value = x;
-        handle.cy.baseVal.value = y;
-
-        radius.x2.baseVal.value = x;
-        radius.y2.baseVal.value = y;
-
-        center.isShifted = false;
-    }
-
     offsetCenterPoint(nx, ny) {
         const {
             elements,
@@ -1361,7 +1316,7 @@ export default class DraggableSVG extends Transformable {
         radius.x2.baseVal.value = x;
         radius.y2.baseVal.value = y;
 
-        center.isShifted = false;
+        center.isShifted = true;
     }
 
     fitControlsToSize() {

--- a/src/js/core/transform/svg/DraggableSVG.js
+++ b/src/js/core/transform/svg/DraggableSVG.js
@@ -1274,6 +1274,96 @@ export default class DraggableSVG extends Transformable {
         center.isShifted = false;
     }
 
+    resetCenterPoint() {
+        const {
+            elements,
+            storage: {
+                controls,
+                handles: {
+                    center: handle,
+                    radius
+                } = {},
+                center
+            } = {},
+            options: {
+                container,
+                isGrouped
+            }
+        } = this;
+
+        if (!center || !handle || !radius) return;
+
+        const { x: bx, y: by, width, height } = this._getBBox();
+
+        const hW = width / 2,
+            hH = height / 2;
+
+        const controlsTransformMatrix = getTransformToElement(controls, controls.parentNode).inverse();
+
+        const nextTransform = isGrouped
+            ? controlsTransformMatrix
+            : controlsTransformMatrix.multiply(getTransformToElement(elements[0], container));
+
+        const { x, y } = pointTo(
+            nextTransform,
+            bx + hW,
+            by + hH
+        );
+
+        handle.cx.baseVal.value = x;
+        handle.cy.baseVal.value = y;
+
+        radius.x2.baseVal.value = x;
+        radius.y2.baseVal.value = y;
+
+        center.isShifted = false;
+    }
+
+    offsetCenterPoint(nx, ny) {
+        const {
+            elements,
+            storage: {
+                controls,
+                handles: {
+                    center: handle,
+                    radius
+                } = {},
+                center
+            } = {},
+            options: {
+                container,
+                isGrouped
+            }
+        } = this;
+
+        if (!center || !handle || !radius) return;
+
+        const { x: bx, y: by, width, height } = this._getBBox();
+
+        const hW = width / 2,
+            hH = height / 2;
+
+        const controlsTransformMatrix = getTransformToElement(controls, controls.parentNode).inverse();
+
+        const nextTransform = isGrouped
+            ? controlsTransformMatrix
+            : controlsTransformMatrix.multiply(getTransformToElement(elements[0], container));
+
+        const { x, y } = pointTo(
+            nextTransform,
+            bx + hW + nx,
+            by + hH + ny
+        );
+
+        handle.cx.baseVal.value = x;
+        handle.cy.baseVal.value = y;
+
+        radius.x2.baseVal.value = x;
+        radius.y2.baseVal.value = y;
+
+        center.isShifted = false;
+    }
+
     fitControlsToSize() {
         const {
             storage = {}


### PR DESCRIPTION
I eventually called the method offsetCenterPoint because setting the centre (ex-centred) would require to define if it is from the container's or the element's origin. Here the origin is the controls' centre.

It works fine when the option rotationPoint is defined. 

A unit test might be useful but I did not see an example to use as a base

Don't hesitate to tell me if you need more help. I continue learning.